### PR TITLE
Set modules as dependencies instead of peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,7 @@
     "url": "https://github.com/orbitdb/eslint-config-orbitdb/issues"
   },
   "homepage": "https://github.com/orbitdb/eslint-config-orbitdb",
-  "peerDependencies": {
-    "eslint": "^5.2.0",
+  "dependencies": {
     "eslint-config-standard": "^11.0.0",
     "eslint-plugin-import": "^2.13.0",
     "eslint-plugin-node": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "url": "https://github.com/orbitdb/eslint-config-orbitdb/issues"
   },
   "homepage": "https://github.com/orbitdb/eslint-config-orbitdb",
-  "dependencies": {
+  "devDependencies": {
     "eslint-config-standard": "^11.0.0",
     "eslint-plugin-import": "^2.13.0",
     "eslint-plugin-node": "^7.0.1",


### PR DESCRIPTION
This PR will change the eslint dependencies from `peerDependecies` to `dependencies`. 

The rationale is that those modules are **required** by this module, so they should always come together with this module. This will also allow much more simplified setup steps for projects to use the module as their linter.