### PR TITLE
Fix example commands to use the correct name of the npm repository

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -15,22 +15,22 @@ Our default export contains all of our ESLint rules.
 * `eslint-config-standard`
 * `eslint`
 
-If you use yarn, run `npm info "eslint-config-orbitdb@latest" peerDependencies` to list the peer dependencies and versions, then run `yarn add --dev <dependency>@<version>` for each listed peer dependency. See below for npm instructions.
+If you use yarn, run `npm info "@orbitdb/eslint-config-orbitdb@latest" peerDependencies` to list the peer dependencies and versions, then run `yarn add --dev <dependency>@<version>` for each listed peer dependency. See below for npm instructions.
 
 1. Install the correct versions of each package, which are listed by the command:
 
   ```sh
-  npm info "eslint-config-orbitdb@latest" peerDependencies
+  npm info "@orbitdb/eslint-config-orbitdb@latest" peerDependencies
   ```
 
   Linux/OSX users can run
 
   ```sh
   (
-    export PKG=eslint-config-orbitdb;
+    export PKG=@orbitdb/eslint-config-orbitdb;
     npm info "$PKG@latest" peerDependencies --json | command sed 's/[\{\},]//g ; s/: /@/g' | xargs yarn add --dev "$PKG@latest"
   )
   ```
 
 
-2. Add `"extends": "eslint-config-orbitdb"` to your .eslintrc
+2. Add `"extends": "@orbitdb/eslint-config-orbitdb"` to your .eslintrc


### PR DESCRIPTION
The example commands did not work. NPM returned 404 when running the `npm info` commands.

Adding the namespace "@orbitdb" to the commands fixes the issue.